### PR TITLE
Add goal parts transform to the transformer

### DIFF
--- a/humanoid_league_transform/config/transformer.yaml
+++ b/humanoid_league_transform/config/transformer.yaml
@@ -12,6 +12,10 @@ lines:
 goals:
   goals_topic: '/goal_in_image'
 
+goal_parts:
+  goal_parts_topic: '/goal_parts_in_image'
+  bar_height: 2.0
+
 obstacles:
   obstacles_topic: '/obstacles_in_image'
 

--- a/humanoid_league_transform/src/humanoid_league_transform/goal_tester.py
+++ b/humanoid_league_transform/src/humanoid_league_transform/goal_tester.py
@@ -3,7 +3,7 @@
 Command line tool to publish balls on the /goal_in_image topic
 """
 import rospy
-from humanoid_league_msgs.msg import GoalInImage, GoalPartsInImage, PostInImage
+from humanoid_league_msgs.msg import GoalInImage, GoalPartsInImage, GoalPostInImage
 import sys
 import signal
 from geometry_msgs.msg import Point, PointStamped
@@ -18,7 +18,7 @@ def point_cb(msg):
     global pub
     gi = GoalInImage()
     gi.header.stamp = rospy.get_rostime() - rospy.Duration(0.2)
-    post = PostInImage()
+    post = GoalPostInImage()
     post.foot_point = Point(msg.point.x, msg.point.y, 0)
     post.confidence = 1
     gi.left_post = post
@@ -50,7 +50,7 @@ if __name__ == "__main__":
 
         gi = GoalInImage()
         gi.header.stamp = rospy.get_rostime() - rospy.Duration(0.2)
-        post = PostInImage()
+        post = GoalPostInImage()
         post.foot_point = Point(x, y, 0)
         post.confidence = 1
         gi.left_post = post
@@ -69,7 +69,7 @@ if __name__ == "__main__":
             print("try again")
             continue
 
-        post2 = PostInImage()
+        post2 = GoalPostInImage()
         post2.foot_point = Point(x, y, 0)
         gi.right_post = post2
 

--- a/humanoid_league_transform/src/humanoid_league_transform/transformer.py
+++ b/humanoid_league_transform/src/humanoid_league_transform/transformer.py
@@ -4,8 +4,8 @@ from bitbots_quintic_walk.msg import WalkingDebug
 from humanoid_league_msgs.msg import BallRelative, BallsInImage, \
 LineInformationInImage, LineInformationRelative, LineSegmentRelative, LineCircleRelative, LineIntersectionRelative, \
 ObstaclesInImage, ObstaclesRelative, ObstacleRelative, \
-GoalInImage, GoalRelative, \
-FieldBoundaryInImage, PixelsRelative, PixelRelative
+GoalInImage, GoalRelative, FieldBoundaryInImage, PixelsRelative, \
+PixelRelative, GoalPartsInImage, GoalPartsRelative, PostRelative, BarRelative
 from geometry_msgs.msg import Point
 from sensor_msgs.msg import CameraInfo, PointCloud2
 import sensor_msgs.point_cloud2 as pc2
@@ -42,6 +42,9 @@ class TransformBall(object):
         rospy.Subscriber(rospy.get_param("~goals/goals_topic", "/goal_in_image"),
                          GoalInImage, self._callback_goal, queue_size=1)
 
+        rospy.Subscriber(rospy.get_param("~goal_parts/goal_parts_topic", "/goal_parts_in_image"),
+                         GoalPartsInImage, self._callback_goal_parts, queue_size=1)
+
         rospy.Subscriber(rospy.get_param("~obstacles/obstacles_topic", "/obstacles_in_image"),
                          ObstaclesInImage, self._callback_obstacles, queue_size=1)
 
@@ -60,12 +63,14 @@ class TransformBall(object):
         if rospy.get_param("~lines/pointcloud", True):
             self.line_relative_pc_pub = rospy.Publisher("line_relative_pc", PointCloud2, queue_size=1)
         self.goal_relative_pub = rospy.Publisher("goal_relative", GoalRelative, queue_size=1)
+        self.goal_parts_relative = rospy.Publisher("goal_parts_relative", GoalPartsRelative, queue_size=1)
         self.obstacle_relative_pub = rospy.Publisher("obstacles_relative", ObstaclesRelative, queue_size=1)
         self.field_boundary_pub = rospy.Publisher("field_boundary_relative", PixelsRelative, queue_size=1)
 
         self.camera_info = None
 
         self.ball_height = rospy.get_param("~ball/ball_radius", 0.075)
+        self.bar_height = rospy.get_param("~goal_parts/bar_height", 2.0)
         self.publish_frame = "base_footprint"
 
         rospy.spin()
@@ -219,6 +224,64 @@ class TransformBall(object):
         goal.confidence = msg.confidence
 
         self.goal_relative_pub.publish(goal)
+
+
+    def _callback_goal_parts(self, msg):
+        if self.camera_info is None:
+            self.warn_camera_info()
+            return
+
+        field = self.get_plane(msg.header.stamp, 0.0, "base_footprint")
+        if field is None:
+            return
+
+        bar_plane = self.get_plane(msg.header.stamp, self.bar_height, "base_footprint")
+        if bar_plane is None:
+            return
+
+        # Create new message
+
+        goal_parts_relative_msg = GoalPartsRelative()
+        goal_parts_relative_msg.header.stamp = msg.header.stamp
+        goal_parts_relative_msg.header.frame_id = self.publish_frame
+
+        # Transform goal posts
+
+        for goal_post_in_image in msg.posts:
+            relative_foot_point = self.transform(goal_post_in_image.foot_point, field, msg.header.stamp)
+            if relative_foot_point is None:
+                rospy.logwarn_throttle(5.0,
+                    "Got a post with foot point ({},{}) I could not transform.".format(
+                        goal_post_in_image.foot_point.x,
+                        goal_post_in_image.foot_point.y,
+                    ))
+            else:
+                post_relative = PostRelative()
+                post_relative.foot_point = relative_foot_point
+                post_relative.confidence = goal_post_in_image.confidence
+                goal_parts_relative_msg.posts.append(post_relative)
+
+        # Transform goal bars
+
+        for goal_bar_in_image in msg.bars:
+            relative_left_point = self.transform(goal_bar_in_image.left_point, bar_plane, msg.header.stamp)
+            relative_right_point = self.transform(goal_bar_in_image.right_point, bar_plane, msg.header.stamp)
+            if relative_right_point is None or relative_left_point is None:
+                rospy.logwarn_throttle(5.0,
+                    "Got a bar with end points ({},{}) and ({},{}) I could not transform.".format(
+                        goal_bar_in_image.left_point.x,
+                        goal_bar_in_image.left_point.y,
+                        goal_bar_in_image.right_point.x,
+                        goal_bar_in_image.right_point.y,
+                    ))
+            else:
+                bar_relative = BarRelative()
+                bar_relative.left_point = relative_left_point
+                bar_relative.right_point = relative_right_point
+                bar_relative.confidence = goal_bar_in_image.confidence
+                goal_parts_relative_msg.bars.append(bar_relative)
+
+        self.goal_parts_relative.publish(goal_parts_relative_msg)
 
     def _callback_obstacles(self, msg):
         if self.camera_info is None:

--- a/humanoid_league_transform/src/humanoid_league_transform/transformer.py
+++ b/humanoid_league_transform/src/humanoid_league_transform/transformer.py
@@ -5,7 +5,7 @@ from humanoid_league_msgs.msg import BallRelative, BallsInImage, \
 LineInformationInImage, LineInformationRelative, LineSegmentRelative, LineCircleRelative, LineIntersectionRelative, \
 ObstaclesInImage, ObstaclesRelative, ObstacleRelative, \
 GoalInImage, GoalRelative, FieldBoundaryInImage, PixelsRelative, \
-PixelRelative, GoalPartsInImage, GoalPartsRelative, PostRelative, BarRelative
+PixelRelative, GoalPartsInImage, GoalPartsRelative, GoalPostRelative, GoalBarRelative
 from geometry_msgs.msg import Point
 from sensor_msgs.msg import CameraInfo, PointCloud2
 import sensor_msgs.point_cloud2 as pc2
@@ -256,7 +256,7 @@ class TransformBall(object):
                         goal_post_in_image.foot_point.y,
                     ))
             else:
-                post_relative = PostRelative()
+                post_relative = GoalPostRelative()
                 post_relative.foot_point = relative_foot_point
                 post_relative.confidence = goal_post_in_image.confidence
                 goal_parts_relative_msg.posts.append(post_relative)
@@ -275,7 +275,7 @@ class TransformBall(object):
                         goal_bar_in_image.right_point.y,
                     ))
             else:
-                bar_relative = BarRelative()
+                bar_relative = GoalBarRelative()
                 bar_relative.left_point = relative_left_point
                 bar_relative.right_point = relative_right_point
                 bar_relative.confidence = goal_bar_in_image.confidence


### PR DESCRIPTION
This adds the ability to transform goal parts (posts and bars) to the transformer. See bit-bots/bitbots_vision#69 for the reasons.