### PR TITLE
team_communication: replace motion_state by robot_state

### DIFF
--- a/humanoid_league_team_communication/config/team_communication_config.yaml
+++ b/humanoid_league_team_communication/config/team_communication_config.yaml
@@ -30,7 +30,7 @@ team_communication:
   # ROS Topics
   team_data: '/team_data'
   strategy: 'role'
-  motion_state: 'motion_state'
+  robot_state: 'robot_state'
   goal: 'goal_relative'
   world_model_node: '/local_world_model'
   position: 'position'

--- a/humanoid_league_team_communication/config/team_communication_config.yaml
+++ b/humanoid_league_team_communication/config/team_communication_config.yaml
@@ -29,10 +29,10 @@ team_communication:
 
   # ROS Topics
   team_data: '/team_data'
-  strategy: 'role'
-  robot_state: 'robot_state'
-  goal: 'goal_relative'
+  strategy: '/strategy'
+  robot_state: '/robot_state'
+  goal: '/goal_relative'
   world_model_node: '/local_world_model'
-  position: 'position'
-  ball: '/balls_relative'
+  position: '/position'
+  ball: '/ball_relative'
   obstacles: '/obstacle_relative'

--- a/humanoid_league_team_communication/include/humanoid_league_team_communication/team_communication.hpp
+++ b/humanoid_league_team_communication/include/humanoid_league_team_communication/team_communication.hpp
@@ -36,7 +36,7 @@ private:
     void recv_thread(void);
     void publish_data(MiTeCom::TeamRobotData);
     void strategy_callback(const humanoid_league_msgs::Strategy);
-    void motion_state_callback(const humanoid_league_msgs::RobotControlState);
+    void robot_state_callback(const humanoid_league_msgs::RobotControlState);
     void position_callback(const humanoid_league_msgs::Position2D);
     void ball_callback(const humanoid_league_msgs::BallRelative);
     void goal_callback(const humanoid_league_msgs::GoalRelative);
@@ -82,7 +82,7 @@ private:
     ros::Timer timer;
 
     ros::Subscriber sub_role;
-    ros::Subscriber sub_motion_state;
+    ros::Subscriber sub_robot_state;
     ros::Subscriber sub_goal;
     ros::Subscriber sub_world;
     ros::Subscriber sub_position;
@@ -97,7 +97,7 @@ private:
 
     std::string teamdata_topic;
     std::string strategy_topic;
-    std::string motion_state_topic;
+    std::string robot_state_topic;
     std::string goal_topic;
     std::string world_model_topic;
     std::string position_topic;

--- a/humanoid_league_team_communication/src/humanoid_league_team_communication/team_communication.cpp
+++ b/humanoid_league_team_communication/src/humanoid_league_team_communication/team_communication.cpp
@@ -21,7 +21,7 @@ TeamCommunication::TeamCommunication() : _nh() {
 
     _nh.getParam("team_communication/team_data", teamdata_topic);
     _nh.getParam("team_communication/strategy", strategy_topic);
-    _nh.getParam("team_communication/motion_state", motion_state_topic);
+    _nh.getParam("team_communication/robot_state", robot_state_topic);
     _nh.getParam("team_communication/goal", goal_topic);
     _nh.getParam("team_communication/world_model_node", world_model_topic);
     _nh.getParam("team_communication/position", position_topic);
@@ -38,7 +38,7 @@ TeamCommunication::TeamCommunication() : _nh() {
 
     sub_role = _nh.subscribe(strategy_topic, 1, &TeamCommunication::strategy_callback, this,
             ros::TransportHints().tcpNoDelay());
-    sub_motion_state = _nh.subscribe(motion_state_topic, 1, &TeamCommunication::motion_state_callback,
+    sub_robot_state = _nh.subscribe(robot_state_topic, 1, &TeamCommunication::robot_state_callback,
             this, ros::TransportHints().tcpNoDelay());
     sub_goal = _nh.subscribe(goal_topic, 1, &TeamCommunication::goal_callback, this,
             ros::TransportHints().tcpNoDelay());
@@ -336,7 +336,7 @@ void TeamCommunication::strategy_callback(const humanoid_league_msgs::Strategy m
     offensive_side_set = true;
 }
 
-void TeamCommunication::motion_state_callback(const humanoid_league_msgs::RobotControlState msg) {
+void TeamCommunication::robot_state_callback(const humanoid_league_msgs::RobotControlState msg) {
     state = msg.state;
     if (state == humanoid_league_msgs::RobotControlState::PENALTY ||
         state == humanoid_league_msgs::RobotControlState::PENALTY_ANIMANTION ||


### PR DESCRIPTION
The team communication listens to motion_state instead of robot_state.