### PR TITLE
Add scaling to transformer

### DIFF
--- a/humanoid_league_transform/config/transformer.yaml
+++ b/humanoid_league_transform/config/transformer.yaml
@@ -24,5 +24,7 @@ camera_info:
   camera_info_topic: 'camera/camera_info'
 
 masks:
-  line_mask: 'line_mask_in_image'
+  line_mask:
+    topic: 'line_mask_in_image'
+    scale: 0.5
 

--- a/humanoid_league_transform/launch/transformer.launch
+++ b/humanoid_league_transform/launch/transformer.launch
@@ -2,7 +2,7 @@
     <arg name="tf_prefix" value="$(eval optenv('ROS_NAMESPACE') + '/' if optenv('ROS_NAMESPACE') !=  '' else '')"/>
     <arg name="use_game_settings" default="false"/>
 
-    <node name="humanoid_league_transformer" pkg="humanoid_league_transform" type="transformer.py">
+    <node name="humanoid_league_transformer" pkg="humanoid_league_transform" output="screen" type="transformer.py">
         <rosparam file="$(find humanoid_league_transform)/config/transformer.yaml" command="load"/>
         <param name="publish_frame" value="$(arg tf_prefix)base_footprint"/>
         <param name="base_footprint_frame" value="$(arg tf_prefix)base_footprint"/>

--- a/humanoid_league_transform/package.xml
+++ b/humanoid_league_transform/package.xml
@@ -22,6 +22,7 @@
   <depend>message_generation</depend>
   <depend>geometry_msgs</depend>
   <depend>bitbots_docs</depend>
+  <depend>python3-opencv</depend>
 
   <exec_depend>rospy</exec_depend>
   <exec_depend>humanoid_league_msgs</exec_depend>

--- a/humanoid_league_transform/src/humanoid_league_transform/transformer.py
+++ b/humanoid_league_transform/src/humanoid_league_transform/transformer.py
@@ -271,7 +271,7 @@ class Transformer(object):
 
         self._field_boundary_pub.publish(field_boundary)
 
-    def _callback_masks(self, msg: Image, publisher: rospy.Publisher, encoding='8UC1', scale=1.0):
+    def _callback_masks(self, msg: Image, publisher: rospy.Publisher, encoding='8UC1', scale=1.0: float):
         """
         Projects a mask from the input image as a pointcloud on the field plane.
         """


### PR DESCRIPTION
## Proposed changes
The transformer does not scale if many line points need to be transformed. 
The resource intensive part lies in the point cloud 2 library and is not trivially optimizable.
I therefore suggest to scale the incomming mask down by a fix factor. The pointcloud is currently very dense, so dense that the localization drops most of its points. 
This reduces the CPU load from 200% to 20% with a scaling by 0.5. The resulting point cloud is nearly indestigishable from the full res one.

## Necessary checks
- [x] Run `catkin build`
- [x] Test on your machine
- [x] Put the PR on our Project board

