### PR TITLE
Remove rate in game controller

### DIFF
--- a/humanoid_league_game_controller/src/humanoid_league_game_controller/receiver.py
+++ b/humanoid_league_game_controller/src/humanoid_league_game_controller/receiver.py
@@ -70,13 +70,11 @@ class GameStateReceiver(object):
 
     def receive_forever(self):
         """ Waits in a loop that is terminated by setting self.running = False """
-        r = rospy.Rate(5)
         while not rospy.is_shutdown():
             try:
                 self.receive_once()
             except IOError as e:
                 rospy.logwarn("Error while sending keepalive: " + str(e))
-            r.sleep()
 
     def receive_once(self):
         """ Receives a package and interprets it.


### PR DESCRIPTION
## Proposed changes
This PR removes the rate from our game controller client. The rate limited the game controller message to 5 Hz leading to a growing message queue because the game controller publishes udp messages with 20 Hz. Receiving from the socket is blocking, therefore no queue is actually needed.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

