### PR TITLE
Use current time in teamdata message

### DIFF
--- a/humanoid_league_team_communication/src/humanoid_league_team_communication/humanoid_league_team_communication.py
+++ b/humanoid_league_team_communication/src/humanoid_league_team_communication/humanoid_league_team_communication.py
@@ -223,8 +223,8 @@ class HumanoidLeagueTeamCommunication:
         team_data = TeamData()
 
         header = Header()
-        header.stamp.secs = message.timestamp.seconds
-        header.stamp.nsecs = message.timestamp.nanos
+        # The robots' times can differ, therefore use our own time here
+        header.stamp = rospy.Time.now()
         header.frame_id = self.map_frame
 
         # Handle timestamp


### PR DESCRIPTION
## Proposed changes
Multiple robots can have different clocks. That might lead to problems in the team communication. This pull request fixes the issue by using the current rostime of the receiving robot for the teamdata message.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

