### PR TITLE
Make it possible to run in multiple teams in local mode

### DIFF
--- a/humanoid_league_team_communication/src/humanoid_league_team_communication/humanoid_league_team_communication.py
+++ b/humanoid_league_team_communication/src/humanoid_league_team_communication/humanoid_league_team_communication.py
@@ -35,8 +35,8 @@ class HumanoidLeagueTeamCommunication:
 
         self.target_host = self.config['target_host']
         if self.target_host == '127.0.0.1':
-            # local mode, bind to port depending on bot id
-            self.target_ports = self.config['local_target_ports']
+            # local mode, bind to port depending on bot id and team id
+            self.target_ports = [port + 10 * self.team_id for port in self.config['local_target_ports']]
             self.receive_port = self.target_ports[self.player_id - 1]
         else:
             self.target_ports = [self.config['target_port']]


### PR DESCRIPTION
## Proposed changes
This change includes the current team id into the port for the robot team communication. This change makes it possible to run robots of multiple teams locally without them interfering. The change only affects the local mode of the team communication, not the one that is used in the competition setup.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

