### PR TITLE
sim game state: Fix publish topic

### DIFF
--- a/humanoid_league_game_controller/scripts/sim_gamestate.py
+++ b/humanoid_league_game_controller/scripts/sim_gamestate.py
@@ -58,7 +58,7 @@ CTRL-C to quit
 
         self.settings = termios.tcgetattr(sys.stdin)
 
-        namespaces = ['amy', 'rory', 'jack', 'donna', 'rose']
+        namespaces = ['']  # ['amy/', 'rory/', 'jack/', 'donna/', 'rose/']
         publishers = [
             self.create_publisher(GameStateMsg, f'{n}/gamestate', QoSProfile(durability=1, depth=1))
             for n in namespaces


### PR DESCRIPTION
## Proposed changes
sim game state: Fix publish topic
We dont us the robot namespaces anymore. Now does not publish on e.g. `/amy/gamestate` but on `/gamestate` instead.