### PR TITLE
team_comm: Fix parsing of protobuf without extensions

### DIFF
--- a/humanoid_league_team_communication/.gitignore
+++ b/humanoid_league_team_communication/.gitignore
@@ -1,1 +1,1 @@
-humanoid_league_team_communication/robocup_extension_pb2.py
+humanoid_league_team_communication/*pb2.py

--- a/humanoid_league_team_communication/CMakeLists.txt
+++ b/humanoid_league_team_communication/CMakeLists.txt
@@ -15,10 +15,18 @@ find_package(bitbots_docs REQUIRED)
 
 find_package(Protobuf REQUIRED)
 
-protobuf_generate_python(PROTO_PY
+protobuf_generate_python(PROTO_PY 
+  humanoid_league_team_communication/RobocupProtocol/robocup.proto)
+add_custom_target(humanoid_league_team_communication_robocup_proto ALL DEPENDS ${PROTO_PY})
+add_custom_command(TARGET humanoid_league_team_communication_robocup_proto
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy ${PROTO_PY}
+  ${CMAKE_SOURCE_DIR}/humanoid_league_team_communication)
+
+protobuf_generate_python(PROTO_PY 
   humanoid_league_team_communication/RobocupProtocol/robocup_extension.proto)
-add_custom_target(humanoid_league_team_communication ALL DEPENDS ${PROTO_PY})
-add_custom_command(TARGET humanoid_league_team_communication
+add_custom_target(humanoid_league_team_communication_robocup_extension_proto ALL DEPENDS ${PROTO_PY})
+add_custom_command(TARGET humanoid_league_team_communication_robocup_extension_proto
   POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy ${PROTO_PY}
   ${CMAKE_SOURCE_DIR}/humanoid_league_team_communication)

--- a/humanoid_league_team_communication/config/team_communication_config.yaml
+++ b/humanoid_league_team_communication/config/team_communication_config.yaml
@@ -14,7 +14,7 @@ team_comm:
       - 4004
 
     # Rate of published messages in Hz
-    rate: 65
+    rate: 10
 
     # average walking speed in [m/s]
     avg_walking_speed: 0.2

--- a/humanoid_league_team_communication/humanoid_league_team_communication/humanoid_league_team_communication.py
+++ b/humanoid_league_team_communication/humanoid_league_team_communication/humanoid_league_team_communication.py
@@ -18,7 +18,7 @@ from tf2_geometry_msgs import PointStamped, PoseStamped
 from bitbots_utils.utils import get_parameters_from_other_node
 from ament_index_python.packages import get_package_share_directory
 
-from humanoid_league_team_communication import robocup_extension_pb2
+from humanoid_league_team_communication import robocup_pb2, robocup_extension_pb2
 
 class HumanoidLeagueTeamCommunication:
     def __init__(self):
@@ -231,8 +231,13 @@ class HumanoidLeagueTeamCommunication:
             if pose.covariance:
                 covariance_proto_to_ros(robot.covariance, pose.covariance)
 
-        message = robocup_extension_pb2.Message()
-        message.ParseFromString(msg)
+        # Try parsing the incoming message as a robocup protocol with extensions, if it fails try the protocol without extensions
+        try:
+            message = robocup_extension_pb2.Message()
+            message.ParseFromString(msg)
+        except:
+            message = robocup_pb2.Message()
+            message.ParseFromString(msg)
 
         player_id = message.current_pose.player_id
         team_id = message.current_pose.team

--- a/humanoid_league_team_communication/humanoid_league_team_communication/humanoid_league_team_communication.py
+++ b/humanoid_league_team_communication/humanoid_league_team_communication/humanoid_league_team_communication.py
@@ -15,7 +15,7 @@ from std_msgs.msg import Header, Float32
 from geometry_msgs.msg import Twist, PoseWithCovarianceStamped, TwistWithCovarianceStamped
 from humanoid_league_msgs.msg import GameState, TeamData, ObstacleRelativeArray, ObstacleRelative, Strategy
 from tf2_geometry_msgs import PointStamped, PoseStamped
-from bitbots_utils.utils import get_parameters_from_other_node
+from bitbots_utils.utils import get_parameter_dict, get_parameters_from_other_node
 from ament_index_python.packages import get_package_share_directory
 
 from humanoid_league_team_communication import robocup_pb2, robocup_extension_pb2
@@ -39,10 +39,10 @@ class HumanoidLeagueTeamCommunication:
         self.target_port = self.node.get_parameter('target_port').get_parameter_value().integer_value
         self.receive_port = self.node.get_parameter('receive_port').get_parameter_value().integer_value
         self.rate = self.node.get_parameter('rate').get_parameter_value().integer_value
-        self.lifetime = self.node.get_parameter('life_time').get_parameter_value().integer_value
+        self.lifetime = self.node.get_parameter('lifetime').get_parameter_value().integer_value
         self.avg_walking_speed = self.node.get_parameter('avg_walking_speed').get_parameter_value().double_value
 
-        self.topics = self.node.get_parameters_by_prefix('topics')
+        self.topics = get_parameter_dict(self.node, 'topics')
         self.map_frame = self.node.get_parameter('map_frame').get_parameter_value().string_value
 
         if self.target_host == '127.0.0.1':

--- a/humanoid_league_team_communication/humanoid_league_team_communication/humanoid_league_team_communication.py
+++ b/humanoid_league_team_communication/humanoid_league_team_communication/humanoid_league_team_communication.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 import math
 import socket
+import struct
+import threading
 from typing import Optional
+
 
 import rclpy
 from rclpy.duration import Duration
 from rclpy.node import Node
-import struct
 
 import tf2_ros
 import transforms3d
@@ -109,6 +111,10 @@ class HumanoidLeagueTeamCommunication:
             self.node.get_clock().sleep_for(Duration(seconds=1))
             rclpy.spin_once(self.node)
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+
+        # Necessary in ROS2, else we are forever stuck receiving messages
+        thread = threading.Thread(target=rclpy.spin, args=(self.node), daemon=True)
+        thread.start()
 
         self.node.create_timer(1 / self.rate, self.send_message)
         self.receive_forever()
@@ -317,8 +323,7 @@ class HumanoidLeagueTeamCommunication:
 
         self.pub_team_data.publish(team_data)
 
-    def send_message(self, event):
-
+    def send_message(self):
         def covariance_ros_to_proto(ros_covariance, fmat3):
             # ROS covariance is row-major 36 x float, protobuf covariance is column-major 9 x float [x, y, θ]
             fmat3.x.x = ros_covariance[0]


### PR DESCRIPTION
## Proposed changes
Compiles both protobuf protocols `robocup_extension.proto`  (as previously) and `robocup.proto`.
We try to parse incoming proto messages as an `robocup_extension.proto`. In case it fails (presumably because the incoming message has no extensions or other extensions, that do not match ours), we try to parse the message as a `robocup.proto`.
This will only parse the standard fields without extensions.

## Related issues
Resolves #93

Still needs testing
