### PR TITLE
Use MultiThreadedExecutor in team communication

### DIFF
--- a/humanoid_league_team_communication/humanoid_league_team_communication/humanoid_league_team_communication.py
+++ b/humanoid_league_team_communication/humanoid_league_team_communication/humanoid_league_team_communication.py
@@ -130,7 +130,7 @@ class HumanoidLeagueTeamCommunication:
         self.strategy = msg
         self.strategy_time = self.get_current_time().to_msg()
 
-    def time_to_ball_cb(self, msg: float):
+    def time_to_ball_cb(self, msg: Float32):
         self.time_to_ball = msg.data
         self.time_to_ball_time = self.get_current_time().to_msg()
 
@@ -195,7 +195,7 @@ class HumanoidLeagueTeamCommunication:
 
     def send_message(self):
         if not self.is_robot_allowed_to_send_message():
-            self.logger.debug("Not allowed to send message")
+            self.logger.debug("Robot is not allowed to send message")
             return
 
         now = self.get_current_time()

--- a/humanoid_league_team_communication/launch/team_comm_standalone.launch
+++ b/humanoid_league_team_communication/launch/team_comm_standalone.launch
@@ -3,6 +3,9 @@
     <!-- Get launch params-->
     <arg name="sim" default="false" description="true: activates simulation time" />
 
+    <!-- load the robot description -->
+    <include file="$(find-pkg-share bitbots_utils)/launch/base.launch" />
+
     <node pkg="humanoid_league_team_communication" exec="team_comm.py" output="screen">
         <param from="$(find-pkg-share humanoid_league_team_communication)/config/team_communication_config.yaml"/>
         <param name="use_sim_time" value="$(var sim)" />


### PR DESCRIPTION
## Proposed changes
The team communication is currently not working in simulation because it is stuck waiting for the /clock topic. These changes start spinning before using `sleep_for` and use the MultiThreadedExecutor instead of the default executor to avoid problems with blocking subscribers.

## Necessary checks
- [ ] Update package version
- [x] Run `colcon build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

